### PR TITLE
Add ProjectilesPerRound > 1 Fire Time Security Check

### DIFF
--- a/src/Standard/LocalWeapon.client.lua
+++ b/src/Standard/LocalWeapon.client.lua
@@ -7,6 +7,7 @@ LocalWeaponSetup is used to properly handle being abruptly cleared.
 --!strict
 
 local Tool = script.Parent
+if not Tool then return end
 local ProjectileReplicationModule = Tool:WaitForChild("ProjectileReplicationReference").Value
 while not ProjectileReplicationModule do
     ProjectileReplicationModule = Tool:WaitForChild("ProjectileReplicationReference").Value

--- a/src/Standard/LocalWeaponSetup.lua
+++ b/src/Standard/LocalWeaponSetup.lua
@@ -111,6 +111,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
         if UserInputService.VREnabled then
             --Create the ammo display.
             local NewVRAmmoGui = Instance.new("BillboardGui")
+            NewVRAmmoGui.Name = "WeaponCrosshair"
             NewVRAmmoGui.StudsOffsetWorldSpace = Vector3.new(-1.2, 0, 0)
             NewVRAmmoGui.Size = UDim2.new(3, 0, 0.75, 0)
             NewVRAmmoGui.Adornee = StartAttachment
@@ -118,6 +119,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             CurrentVRAmmoGui = NewVRAmmoGui
 
             AmmoText = Instance.new("TextLabel")
+            AmmoText.Name = "AmmoText"
             AmmoText.BackgroundTransparency = 1
             AmmoText.Size = UDim2.new(1, 0, 0.7, 0)
             AmmoText.Position = UDim2.new(0, 0, 0, 0)
@@ -131,6 +133,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             AmmoText.Parent = NewVRAmmoGui
 
             ReloadingText = Instance.new("TextLabel")
+            ReloadingText.Name = "ReloadingText"
             ReloadingText.BackgroundTransparency = 1
             ReloadingText.Size = UDim2.new(1, 0, 0.35, 0)
             ReloadingText.Position = UDim2.new(0, 0, 0.65, 0)
@@ -151,6 +154,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             CrosshairGui.Parent = Players.LocalPlayer:WaitForChild("PlayerGui")
 
             CrossFrame = Instance.new("Frame")
+            CrossFrame.Name = "Crosshair"
             CrossFrame.BackgroundTransparency = 1
             CrossFrame.AnchorPoint = Vector2.new(0.5, 0.5)
             CrossFrame.Size = UDim2.new(0.075, 0, 0.075, 0)
@@ -158,6 +162,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             CrossFrame.Parent = CrosshairGui
 
             local CrosshairTop = Instance.new("Frame")
+            CrosshairTop.Name = "CrosshairTop"
             CrosshairTop.BackgroundColor3 = Color3.new(1, 1, 1)
             CrosshairTop.BorderColor3 = Color3.new(0, 0, 0)
             CrosshairTop.Size = UDim2.new(0, 2, 0.3, 0)
@@ -166,6 +171,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             CrosshairTop.Parent = CrossFrame
 
             local CrosshairBottom = Instance.new("Frame")
+            CrosshairBottom.Name = "CrosshairBottom"
             CrosshairBottom.BackgroundColor3 = Color3.new(1, 1, 1)
             CrosshairBottom.BorderColor3 = Color3.new(0, 0, 0)
             CrosshairBottom.Size = UDim2.new(0, 2, 0.3, 0)
@@ -174,6 +180,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             CrosshairBottom.Parent = CrossFrame
 
             local CrosshairLeft = Instance.new("Frame")
+            CrosshairLeft.Name = "CrosshairLeft"
             CrosshairLeft.BackgroundColor3 = Color3.new(1, 1, 1)
             CrosshairLeft.BorderColor3 = Color3.new(0, 0, 0)
             CrosshairLeft.Size = UDim2.new(0.3, 0, 0, 2)
@@ -182,6 +189,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             CrosshairLeft.Parent = CrossFrame
 
             local CrosshairRight = Instance.new("Frame")
+            CrosshairRight.Name = "CrosshairRight"
             CrosshairRight.BackgroundColor3 = Color3.new(1, 1, 1)
             CrosshairRight.BorderColor3 = Color3.new(0, 0, 0)
             CrosshairRight.Size = UDim2.new(0.3, 0, 0, 2)
@@ -190,6 +198,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             CrosshairRight.Parent = CrossFrame
 
             AmmoText = Instance.new("TextLabel")
+            AmmoText.Name = "AmmoText"
             AmmoText.BackgroundTransparency = 1
             AmmoText.Size = UDim2.new(5, 0, 0.4, 0)
             AmmoText.Position = UDim2.new(0.7, 2, 0.55, 2)
@@ -203,6 +212,7 @@ function LocalWeaponSetup:SetupTool(Tool: Tool): ()
             AmmoText.Parent = CrossFrame
 
             ReloadingText = Instance.new("TextLabel")
+            ReloadingText.Name = "ReloadingText"
             ReloadingText.BackgroundTransparency = 1
             ReloadingText.Size = UDim2.new(5, 0, 0.3, 0)
             ReloadingText.Position = UDim2.new(0.8, 2, 0.9, 2)

--- a/src/Standard/ServerWeapon.server.lua
+++ b/src/Standard/ServerWeapon.server.lua
@@ -8,6 +8,7 @@ Handles the weapon on the server.
 local TweenService = game:GetService("TweenService")
 
 local Tool = script.Parent
+if not Tool then return end
 local Handle = Tool:WaitForChild("Handle")
 local ChargeMotor = Handle:WaitForChild("ChargeMotor")
 local ChargeAttachment = Handle:WaitForChild("ChargeAttachment")

--- a/src/Standard/init.lua
+++ b/src/Standard/init.lua
@@ -33,6 +33,11 @@ function Standard.CreateStandardWeapon(WeaponModel: Tool): ()
     LastFireTimeValue.Value = 0
     LastFireTimeValue.Parent = StateFolder
 
+    local LastFireRemainingRoundsValue = Instance.new("IntValue")
+    LastFireRemainingRoundsValue.Name = "LastFireRemainingRounds"
+    LastFireRemainingRoundsValue.Value = 0
+    LastFireRemainingRoundsValue.Parent = StateFolder
+
     local RemainingRoundsValue = Instance.new("IntValue")
     RemainingRoundsValue.Name = "RemainingRounds"
     RemainingRoundsValue.Value = ConfigurationData.TotalRounds

--- a/src/init.lua
+++ b/src/init.lua
@@ -359,17 +359,19 @@ function ProjectileReplication:SetUp(): ()
             local RemainingRoundsValue = State:FindFirstChild("RemainingRounds") :: IntValue
             local ReloadingValue = State:FindFirstChild("Reloading") :: BoolValue
             local LastFireTimeValue = State:FindFirstChild("LastFireTime") :: NumberValue
+            local LastFireRemainingRoundsValue = State:FindFirstChild("LastFireRemainingRounds") :: NumberValue
             if not RemainingRoundsValue or not ReloadingValue then return end
 
             --Return if the firing is invalid.
             if ReloadingValue.Value then return end
             if RemainingRoundsValue.Value <= 0 then return end
             if (StartCFrame.Position - Handle.Position).Magnitude > 10 and not Humnanoid.Sit and not Humnanoid.SeatPart then return end --Local trams do not replicate to the server, so the projectiles shots will claim to be far away.
-            --TODO: Security check below does not apply to shotgun. This is exploitable.
-            if tick() - LastFireTimeValue.Value < ConfigurationData.CooldownTime * 0.5 and (not ConfigurationData.ProjectilesPerRound or ConfigurationData.ProjectilesPerRound == 1) then return end
+            local IsCloseToLastFire = (tick() - LastFireTimeValue.Value < ConfigurationData.CooldownTime * 0.5)
+            if IsCloseToLastFire and LastFireRemainingRoundsValue.Value <= 0 then return end
 
             --Fire the projectile.
             LastFireTimeValue.Value = tick()
+            LastFireRemainingRoundsValue.Value = (IsCloseToLastFire and LastFireRemainingRoundsValue.Value - 1 or ConfigurationData.ProjectilesPerRound - 1)
             RemainingRoundsValue.Value = RemainingRoundsValue.Value - 1
             (self :: any):Fire(StartCFrame, Handle, ConfigurationData.ProjectilePreset, Character)
         end)

--- a/src/init.lua
+++ b/src/init.lua
@@ -209,6 +209,7 @@ function ProjectileReplication:Aim(Player: Player, AimPosition: Vector3): ()
         local BodyGyro, HumanoidChangedEvent = nil, nil
         if Player == Players.LocalPlayer then
             BodyGyro = Instance.new("BodyGyro")
+            BodyGyro.Name = "ProjectileReplicationAimGyro"
             BodyGyro.D = 100
             BodyGyro.P = 10000
             BodyGyro.MaxTorque = Vector3.new(0, Humanoid.Sit and 0 or math.huge, 0)

--- a/src/init.lua
+++ b/src/init.lua
@@ -372,7 +372,7 @@ function ProjectileReplication:SetUp(): ()
 
             --Fire the projectile.
             LastFireTimeValue.Value = tick()
-            LastFireRemainingRoundsValue.Value = (IsCloseToLastFire and LastFireRemainingRoundsValue.Value - 1 or ConfigurationData.ProjectilesPerRound - 1)
+            LastFireRemainingRoundsValue.Value = (IsCloseToLastFire and LastFireRemainingRoundsValue.Value - 1 or (ConfigurationData.ProjectilesPerRound or 1) - 1)
             RemainingRoundsValue.Value = RemainingRoundsValue.Value - 1
             (self :: any):Fire(StartCFrame, Handle, ConfigurationData.ProjectilePreset, Character)
         end)


### PR DESCRIPTION
The primary purpose of this pull request is to add a security check for the fire time when `ProjectilesPerRound` is >1. Currently, this check is bypassed and a rapid-fire can be done by a malicious user. This expands the check to work with multiple rounds in a shot. Additionally, an error when a tool is created and instantly deleted is fixed and all parented instances now have names.