### PR TITLE
Support Activating/Deactivating Events

### DIFF
--- a/src/Standard/LocalWeaponSetup/init.luau
+++ b/src/Standard/LocalWeaponSetup/init.luau
@@ -58,9 +58,11 @@ function LocalWeaponSetup.SetupTool(self: LocalWeaponSetup, Tool: Tool): ()
         --Connect using the tool.
         Input.StartFire:Connect(function()
             if not Equipped then return end
+            Tool:Activate()
             WeaponState:Fire()
         end)
         Input.EndFire:Connect(function()
+            Tool:Deactivate()
             WeaponState:StopFiring()
         end)
         Input.Reload:Connect(function()


### PR DESCRIPTION
Chargeup items currently don't work on mobile due to the custom UIs not supporting `Activated` and `Deactivated` events. This adds compatibility for these events and works with non-standard scripts included in tools.