### PR TITLE
Fixes issue with setup running multiple times.

### DIFF
--- a/src/Standard/LocalWeaponSetup/init.luau
+++ b/src/Standard/LocalWeaponSetup/init.luau
@@ -21,11 +21,17 @@ local LocalWeaponSetup = {}
 
 export type LocalWeaponSetup = typeof(LocalWeaponSetup)
 
+local AlreadySetupTools = {} :: {Tool}
+
 
 --[[
 Sets up a tool.
 --]]
 function LocalWeaponSetup.SetupTool(self: LocalWeaponSetup, Tool: Tool): ()
+    if table.find(AlreadySetupTools, Tool) then
+        return
+    end
+
     local ProjectileReplication = require(script.Parent.Parent) :: any
     
     local Configuration = require(Tool:WaitForChild("Configuration")) :: Types.StandardConfiguration
@@ -96,6 +102,9 @@ function LocalWeaponSetup.SetupTool(self: LocalWeaponSetup, Tool: Tool): ()
             CurrentInput = nil
         end
     end)
+
+    -- Add tool to already setup table
+    table.insert(AlreadySetupTools, Tool)
 end
 
 --[[


### PR DESCRIPTION
When the tools parent changes, for example, to temporarily save the player's current tools in a folder separate from the player's backpack. Roblox would rerun the LocalWeapon script when parenting the tool back to the player's backpack, causing `:SetupTool()` to run again. This would create multiple connections of `.Equipped` and `.Unequipped`, which as a side effect causes the gun to run `:Fire()` numerous times with one click.

To fix this I've added a debounce table, that holds the tools already set up.