### PR TITLE
Fix Duplicate Local Setup

### DIFF
--- a/src/Standard/LocalWeaponSetup/init.luau
+++ b/src/Standard/LocalWeaponSetup/init.luau
@@ -2,6 +2,8 @@
 --Moved out of LocalWeapon to make it safe for destroying.
 --!strict
 
+local TOOL_SET_UP_TAG = "ProjectileReplicationLoadedTool"
+
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local UserInputService = game:GetService("UserInputService")
@@ -26,6 +28,9 @@ export type LocalWeaponSetup = typeof(LocalWeaponSetup)
 Sets up a tool.
 --]]
 function LocalWeaponSetup.SetupTool(self: LocalWeaponSetup, Tool: Tool): ()
+    if Tool:HasTag(TOOL_SET_UP_TAG) then return end
+    Tool:AddTag(TOOL_SET_UP_TAG)
+
     local ProjectileReplication = require(script.Parent.Parent) :: any
     
     local Configuration = require(Tool:WaitForChild("Configuration")) :: Types.StandardConfiguration


### PR DESCRIPTION
Alternative implementation of #14 without using a table that would cause a memory leak.

Also updates Nexus Appendage for updated `IKControl` constraints. **This does not make it ready for the Avatar Joint Upgrade due to other instances of changing motors**.